### PR TITLE
feat: pass the env name via LAUNCH_DARKLY_ENVIRONMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ setupNodeEvents(on, config) {
 }
 ```
 
-Reads the environment variables `LAUNCH_DARKLY_PROJECT_KEY` and `LAUNCH_DARKLY_AUTH_TOKEN` to initialize the LD client. Assumes the LD environment name is "test".
+Reads the environment variables `LAUNCH_DARKLY_PROJECT_KEY` and `LAUNCH_DARKLY_AUTH_TOKEN` to initialize the LD client. You can pass the LD environment name via `LAUNCH_DARKLY_ENVIRONMENT`, otherwise it assumes the LD environment name is "test".
 
 ### Explicit registration (old)
 

--- a/src/index.js
+++ b/src/index.js
@@ -275,11 +275,20 @@ function initCypress(on, config) {
     process.env.LAUNCH_DARKLY_PROJECT_KEY &&
     process.env.LAUNCH_DARKLY_AUTH_TOKEN
   ) {
-    console.log('cypress-ld-control: initializing LD client')
+    // the name of your environment to use
+    const environment =
+      'LAUNCH_DARKLY_ENVIRONMENT' in process.env.LAUNCH_DARKLY_ENVIRONMENT &&
+      process.env.LAUNCH_DARKLY_ENVIRONMENT
+        ? process.env.LAUNCH_DARKLY_ENVIRONMENT
+        : 'test'
+    console.log(
+      'cypress-ld-control: initializing LD client for environment "%s"',
+      environment,
+    )
     const options = {
       projectKey: process.env.LAUNCH_DARKLY_PROJECT_KEY,
       authToken: process.env.LAUNCH_DARKLY_AUTH_TOKEN,
-      environment: 'test', // the name of your environment to use
+      environment,
     }
     const ldApiTasks = initLaunchDarklyApiTasks(options)
     if (!ldApiTasks) {


### PR DESCRIPTION
- closes #5