### PR TITLE
feat: start supporting multiple LD projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ setupNodeEvents(on, config) {
 
 Reads the environment variables `LAUNCH_DARKLY_PROJECT_KEY` and `LAUNCH_DARKLY_AUTH_TOKEN` to initialize the LD client. You can pass the LD environment name via `LAUNCH_DARKLY_ENVIRONMENT`, otherwise it assumes the LD environment name is "test".
 
+### initCypressMultipleProjects
+
+Sometimes you might have several LaunchDarkly projects. You can control each one, and all you need is `LAUNCH_DARKLY_AUTH_TOKEN` environment variable.
+
+```js
+// cypress.config.js
+const { initCypressMultipleProjects } = require('cypress-ld-control')
+setupNodeEvents(on, config) {
+  // list all the LD projects you want to use
+  const projects = [
+    {
+      projectKey: 'demo-project',
+      environment: 'test',
+    },
+    {
+      projectKey: 'api-project',
+      environment: 'test',
+    },
+  ]
+
+  initCypressMultipleProjects(projects, on, config)
+
+  // IMPORTANT: return the updated config object
+  return config
+}
+```
+
+When calling the `cy` custom commands from [commands.js](./commands.js) pass the project key, for example
+
+```js
+cy.getFeatureFlag(featureFlagKey, projectKey)
+```
+
 ### Explicit registration (old)
 
 **Tip:** you might want to check if the environment variables `and` are set and only initialize the tasks in that case.

--- a/commands.js
+++ b/commands.js
@@ -4,7 +4,18 @@ if (!Cypress.isLaunchDarklyControlInitialized) {
       return Boolean(Cypress.env('haveLaunchDarklyApi'))
     }
 
-  Cypress.Commands.add('getFeatureFlag', (featureFlagKey) => {
+  Cypress.Commands.add('getFeatureFlag', (featureFlagKey, projectKey) => {
+    if (projectKey) {
+      // multiple LD projects
+      return cy.task(
+        'cypress-ld-control:getFeatureFlag',
+        { featureFlagKey, projectKey },
+        {
+          log: false,
+        },
+      )
+    }
+
     return cy.task('cypress-ld-control:getFeatureFlag', featureFlagKey, {
       log: false,
     })

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -5,10 +5,11 @@ import '../../commands'
 
 describe('Cypress LaunchDarkly control', () => {
   if (Cypress.isLaunchDarklyControlInitialized()) {
+    const projectKey = 'demo-project'
     const featureFlagKey = 'testing-launch-darkly-control-from-cypress'
 
     it('fetches the feature flag', () => {
-      cy.getFeatureFlag(featureFlagKey)
+      cy.getFeatureFlag(featureFlagKey, projectKey).then(console.log)
     })
 
     it('sets the flag for a user')

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-const { initCypress } = require('../../src')
+const { initCypress, initCypressMultipleProjects } = require('../../src')
 
 /**
  * @type {Cypress.PluginConfig}
@@ -8,7 +8,16 @@ const { initCypress } = require('../../src')
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-  initCypress(on, config)
+  // initCypress(on, config)
+
+  // list all the LD projects you want to use
+  const projects = [
+    {
+      projectKey: 'demo-project',
+      environment: 'test',
+    },
+  ]
+  initCypressMultipleProjects(projects, on, config)
 
   // IMPORTANT: return the updated config object
   return config

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -15,7 +15,7 @@ declare namespace Cypress {
     /**
      * Returns information about the given feature flag
      */
-    getFeatureFlag(featureFlagKey: string): Chainable<any>
+    getFeatureFlag(featureFlagKey: string, projectKey?: string): Chainable<any>
 
     /**
      * Sets the feature flag value for the given user.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,28 @@
 
 import './globals'
 
+/**
+ * Initializes a single LD client using `LAUNCH_DARKLY_PROJECT_KEY`
+ * and `LAUNCH_DARKLY_AUTH_TOKEN` environment variables, plus
+ * optional `LAUNCH_DARKLY_ENVIRONMENT`. Registers Cypress tasks.
+ */
 export function initCypress(
+  on: Cypress.PluginEvents,
+  config: Cypress.PluginConfigOptions,
+): Cypress.PluginConfigOptions
+
+interface LaunchDarklyProject {
+  projectKey: string
+  environment: string
+}
+
+/**
+ * Creates a separate LaunchDarkly API client for each project
+ * specified in the `projects` array. Grabs the LD API auth token
+ * from the environment variable `LAUNCH_DARKLY_AUTH_TOKEN`.
+ */
+export function initCypressMultipleProjects(
+  projects: LaunchDarklyProject[],
   on: Cypress.PluginEvents,
   config: Cypress.PluginConfigOptions,
 ): Cypress.PluginConfigOptions


### PR DESCRIPTION
- closes #7
- implements multiple project initialization and the `cy.getFeatureFlag(featureFlagKey, projectKey)` command